### PR TITLE
Adding some logic to handle different platforms and compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@
 *.out
 *.app
 build
+
+# Python
+*.egg-info/
+*.pyc

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+'''Benchmark Astropy's LS fast_impl versus a baseline C++ implementation
+'''
 
 import timeit
 
@@ -11,16 +13,20 @@ _limiter = threadpoolctl.threadpool_limits(1)
 
 rand = np.random.default_rng(43)
 
+# The Gowanlock+ paper uses N_t=3554 as their single-object dataset.
+# N_f=10**5 is a typical number of freq bins (we call this M)
 N = 3554
 dtype = np.float64
 df = dtype(0.1)
-M = 10**5  # num freq bins
+M = 10**5
 
+# Generate fake data
 random = np.random.default_rng(5043)
 t = np.sort(random.uniform(0, 10, N).astype(dtype))
 y = random.normal(size=N).astype(dtype)
 dy = random.uniform(0.5, 2.0, N).astype(dtype)
 
+# And some derived quantities
 w = dy**-2.
 w /= w.sum()  # for now, the C++ code will require normalized w
 f0 = dtype(df/2)  # f0=0 yields power[0] = nan. let's use f0=df/2, from LombScargle.autofrequency
@@ -28,20 +34,20 @@ f0 = dtype(df/2)  # f0=0 yields power[0] = nan. let's use f0=df/2, from LombScar
 print(f'Running with {N=}, {M=}, dtype {dtype.__name__}')
 
 if do_nufft:=True:
-    import nufft_ls
-    nufft_ls_compute = {np.float32: nufft_ls.baseline_compute_float,
-                        np.float64: nufft_ls.baseline_compute,
+    import nufft_ls.cpu
+    nufft_ls_compute = {np.float32: nufft_ls.cpu.baseline_compute_float,
+                        np.float64: nufft_ls.cpu.baseline_compute,
                     }[dtype]
 
     # static void compute(size_t N, const Scalar* t, const Scalar* y, const Scalar* w, size_t M,
-    #                       const Scalar f0, const Scalar df, Scalar* power) {
+    #                       const Scalar f0, const Scalar df, Scalar* power);
 
     power = np.zeros(M, dtype=y.dtype)
 
     nufft_ls_compute(t, y, w, f0, df, power)
 
     time = timeit.timeit('nufft_ls_compute(t, y, w, f0, df, power)',
-                number=(nloop:=1), globals=globals(),
+                number=(nloop:=10), globals=globals(),
             )
     print(f'baseline took {time/nloop:.4g} sec')
 

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -47,7 +47,7 @@ if do_nufft:=True:
     nufft_ls_compute(t, y, w, f0, df, power)
 
     time = timeit.timeit('nufft_ls_compute(t, y, w, f0, df, power)',
-                number=(nloop:=10), globals=globals(),
+                number=(nloop:=3), globals=globals(),
             )
     print(f'baseline took {time/nloop:.4g} sec')
 

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -11,10 +11,10 @@ _limiter = threadpoolctl.threadpool_limits(1)
 
 rand = np.random.default_rng(43)
 
-N = 355
+N = 3554
 dtype = np.float64
 df = dtype(0.1)
-M = 10**6  # num freq bins
+M = 10**5  # num freq bins
 
 random = np.random.default_rng(5043)
 t = np.sort(random.uniform(0, 10, N).astype(dtype))
@@ -36,11 +36,13 @@ if do_nufft:=True:
     # static void compute(size_t N, const Scalar* t, const Scalar* y, const Scalar* w, size_t M,
     #                       const Scalar f0, const Scalar df, Scalar* power) {
 
-    power = np.empty(M, dtype=y.dtype)
+    power = np.zeros(M, dtype=y.dtype)
 
     nufft_ls_compute(t, y, w, f0, df, power)
 
-    time = timeit.timeit('nufft_ls_compute(t, y, w, f0, df, power)', number=(nloop:=1), globals=globals())
+    time = timeit.timeit('nufft_ls_compute(t, y, w, f0, df, power)',
+                number=(nloop:=1), globals=globals(),
+            )
     print(f'baseline took {time/nloop:.4g} sec')
 
 if do_astropy:=True:

--- a/env/environment-gnu.sh
+++ b/env/environment-gnu.sh
@@ -3,3 +3,11 @@ module load gcc/11
 module load python/3.9
 
 . venv/bin/activate
+
+export CC=gcc
+export CXX=g++
+
+# only required for 'python setup.py develop'
+# because `pip install -e .` doesn't seem to use these vars...?
+export LDSHARED="$CC -L$(python3-config --prefix)/lib -shared"
+export LDCXXSHARED="$CXX -L$(python3-config --prefix)/lib -shared"

--- a/include/periodogram/periodogram.hpp
+++ b/include/periodogram/periodogram.hpp
@@ -27,7 +27,7 @@ struct baseline {
       Scalar omega = m * domega + omega0;
       Scalar Sh = Scalar(0), Ch = Scalar(0);
       Scalar S2 = Scalar(0), C2 = Scalar(0);
-      #pragma omp simd simdlen(16)
+      #pragma omp simd simdlen(64/sizeof(Scalar))
       for (size_t n = 0; n < N; ++n) {
         Scalar wn = w[n];
         Scalar hn = wn * y[n];

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,72 @@
 from glob import glob
 
 from setuptools import setup
-import pybind11.setup_helpers
-from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-compile_link_args = ['-march=native',
-                     '-Ofast',
-                     '-fopenmp',
-                     #'-unroll',
-                     
-                     # icc
-                     #'-march=core-avx2',  # for rome on icc
-                     #'-fp-model', 'strict',
+from pybind11.setup_helpers import Pybind11Extension, build_ext, MACOS, WIN, has_flag, intree_extensions
 
-                     # clang
-                     #'-stdlib=libc++',
-                     #'-fveclib=SVML',
-                     #'-lsvml'
 
-                     # aocc
-                     #'-std=c++11',
-                     #'-ffast-math',
-                     #'-lamdlibm',
-                     #'-lm',
-                     ]
-
-ext_modules = pybind11.setup_helpers.intree_extensions(["src/nufft_ls/cpu.cpp"])
-
+ext_modules = intree_extensions(["src/nufft_ls/cpu.cpp"])
 ext_modules[0].include_dirs = ['include/']
-ext_modules[0].extra_compile_args = compile_link_args
-ext_modules[0].extra_link_args = compile_link_args
 ext_modules[0].language = 'c++'
 
-setup(name="nufft_ls",
-    version="0.0.1",
+class custom_build_ext(build_ext):
+    def build_extensions(self):
+        # Handle platform specific optimization flags
+        if WIN:
+            # I don't know what optimization flags would be right on Windows
+            pass
+        else:
+            cflags = []
+            ldflags = []
+            for flag in [
+                "-march=native",
+                "-Ofast",
+                "-fopenmp",
+                "-funroll-loops",
+                "-ffast-math",
+            ]:
+                if has_flag(self.compiler, flag):
+                    cflags.append(flag)
+
+            # None of the rest of these will work on Mac
+            if not MACOS:
+                cc = " ".join(self.compiler.compiler_so[:2])
+                
+                # TODO: this can give a huge speedup when using the Intel compiler on an AMD CPU
+                # but if we're on an Intel CPU, we want -march=native instead. How to detect this?
+                #if "icc" in cc:
+                #    if has_flag(self.compiler, "-march=core-avx2"):
+                #        cflags += ["-march=core-avx2"]
+                
+                if "clang" in cc:
+                    cflags += ["-stdlib=libc++"]
+                    ldflags += ["-stdlib=libc++"]
+                    # These are optimistic/untested commands that might work if one has
+                    # an SVML lib available for Clang to link against
+                    #cflags += ["-fveclib=SVML"]
+                    #ldflags += ["-lsvml"]
+
+                # TODO: AOCC on Clang 13 seems to only support C++11
+                # but the Pybind11 auto-detection doesn't seem to notice
+                #if "aocc" in cc:  # TODO: the AOCC executable is actually just named `clang`...
+                #    cflags += ["-std=c++11"]
+                #    ldflags += ["-lamdlibm", "-lm"]  # not sure if these help...
+
+            for ext in self.extensions:
+                ext.extra_compile_args += cflags
+                ext.extra_link_args += ldflags
+
+        build_ext.build_extensions(self)
+
+
+setup(
+    name="nufft_ls",
+    version="0.0.2",
     url="https://github.com/dfm/nufft-ls",
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.8",
+    install_requires=["numpy", "astropy", "threadpoolctl"],
     ext_modules=ext_modules,
-    cmdclass={"build_ext": build_ext},
+    cmdclass={"build_ext": custom_build_ext},
     package_dir={'':'src'},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 from glob import glob
 
 from setuptools import setup
+import pybind11.setup_helpers
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 compile_link_args = ['-march=native',
                      '-Ofast',
                      '-fopenmp',
-                     #'-funroll-loops',
+                     #'-unroll',
                      
                      # icc
                      #'-march=core-avx2',  # for rome on icc
@@ -24,16 +25,12 @@ compile_link_args = ['-march=native',
                      #'-lm',
                      ]
 
-ext_modules = [
-    Pybind11Extension(
-        "nufft_ls",
-        sorted(glob("src/*.cpp")),  # Sort source files for reproducibility
-        include_dirs=['include/'],
-        extra_compile_args=compile_link_args,
-        extra_link_args=compile_link_args,
-        language='c++',
-    ),
-]
+ext_modules = pybind11.setup_helpers.intree_extensions(["src/nufft_ls/cpu.cpp"])
+
+ext_modules[0].include_dirs = ['include/']
+ext_modules[0].extra_compile_args = compile_link_args
+ext_modules[0].extra_link_args = compile_link_args
+ext_modules[0].language = 'c++'
 
 setup(name="nufft_ls",
     version="0.0.1",
@@ -42,4 +39,5 @@ setup(name="nufft_ls",
     python_requires=">=3.6",
     ext_modules=ext_modules,
     cmdclass={"build_ext": build_ext},
+    package_dir={'':'src'},
 )

--- a/src/nufft_ls/cpu.cpp
+++ b/src/nufft_ls/cpu.cpp
@@ -29,30 +29,11 @@ namespace periodogram_pybind {
     };
 }
 
-PYBIND11_MODULE(nufft_ls, m) {
-    m.doc() = "nufft_ls module";
+PYBIND11_MODULE(cpu, m) {
+    m.doc() = "nufft_ls.cpu module";
     //m.def("trig_sum_naive_compute", &periodogram::trig_sum_naive::compute<double>, "trig_sum_naive::compute<double>");
     //m.def("trig_sum_naive_compute_float", &periodogram::trig_sum_naive::compute<float>, "trig_sum_naive::compute<float>");
 
     m.def("baseline_compute", &periodogram_pybind::baseline::compute<double>, "periodogram::baseline::compute<double>");
     m.def("baseline_compute_float", &periodogram_pybind::baseline::compute<float>, "periodogram::baseline::compute<float>");
 }
-
-
-/*
-namespace periodogram_pybind {
-    struct baseline {
-        // TODO: do we need to disable forcecast?
-        static void compute(py::array_t<double> t){
-                        auto tunchecked = t.unchecked<1>();
-                        const double* tptr = tunchecked.data(0);
-                    }
-    };
-}
-
-PYBIND11_MODULE(nufft_ls, m) {
-    m.doc() = "nufft_ls module";
-
-    m.def("baseline_compute", &periodogram_pybind::baseline::compute, "periodogram::baseline::compute<double>");
-}
-*/


### PR DESCRIPTION
This adds some generally untested logic based on @lgarrison's suggested compiler flags that tries to set them sensibly based on the environment.

Here are the results I get when running the benchmark on my M1 apple laptop:

```
Running with N=3554, M=100000, dtype float64
baseline took 5.052 sec
astropy took 11.71 sec
frac isclose 100%
max frac err 3.865e-09
```