### PR TITLE
Initial phase winding implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ message(STATUS "Using CMake version: " ${CMAKE_VERSION})
 # find_package(FFTW REQUIRED COMPONENTS FLOAT_LIB DOUBLE_LIB)
 # link_libraries(${FFTW_FLOAT_LIB} ${FFTW_DOUBLE_LIB})
 
-add_compile_options(-Wall -pedantic -Wextra -Werror -O3 -funroll-loops -Wno-unknown-pragmas)
+add_compile_options(-Wall -pedantic -Wextra -Werror -O3 -funroll-loops -fopenmp)
 include_directories(${CMAKE_CURRENT_LIST_DIR}/include)
 
 # set(FINUFFT_INCLUDE_DIRS

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -3,69 +3,112 @@
 '''
 
 import timeit
+import argparse
 
 import numpy as np
 from astropy.timeseries.periodograms.lombscargle.implementations import fast_impl
 import threadpoolctl
 
-# don't let numpy do multithreading behind our back!
-_limiter = threadpoolctl.threadpool_limits(1)
-
-rand = np.random.default_rng(43)
-
 # The Gowanlock+ paper uses N_t=3554 as their single-object dataset.
 # N_f=10**5 is a typical number of freq bins (we call this M)
-N = 3554
-dtype = np.float64
-df = dtype(0.1)
-M = 10**5
+DEFAULT_N = 3554
+DEFAULT_M = 10**5
+DEFAULT_DTYPE = 'f8'
+DEFAULT_DF = np.dtype(DEFAULT_DTYPE).type(0.1)
 
-# Generate fake data
-random = np.random.default_rng(5043)
-t = np.sort(random.uniform(0, 10, N).astype(dtype))
-y = random.normal(size=N).astype(dtype)
-dy = random.uniform(0.5, 2.0, N).astype(dtype)
+def main(N, M, dtype, df=DEFAULT_DF,
+            do_baseline=True, do_astropy=True, do_winding=True):
+    # process args
+    dtype = np.dtype(dtype).type
+    df = dtype(df)
 
-# And some derived quantities
-w = dy**-2.
-w /= w.sum()  # for now, the C++ code will require normalized w
-f0 = dtype(df/2)  # f0=0 yields power[0] = nan. let's use f0=df/2, from LombScargle.autofrequency
+    # don't let numpy do multithreading behind our back!
+    _limiter = threadpoolctl.threadpool_limits(1)
 
-print(f'Running with {N=}, {M=}, dtype {dtype.__name__}')
+    rand = np.random.default_rng(43)
 
-if do_nufft:=True:
-    import nufft_ls.cpu
-    nufft_ls_compute = {np.float32: nufft_ls.cpu.baseline_compute_float,
-                        np.float64: nufft_ls.cpu.baseline_compute,
-                    }[dtype]
+    # Generate fake data
+    random = np.random.default_rng(5043)
+    t = np.sort(random.uniform(0, 10, N).astype(dtype))
+    y = random.normal(size=N).astype(dtype)
+    dy = random.uniform(0.5, 2.0, N).astype(dtype)
 
-    # static void compute(size_t N, const Scalar* t, const Scalar* y, const Scalar* w, size_t M,
-    #                       const Scalar f0, const Scalar df, Scalar* power);
+    # And some derived quantities
+    w = dy**-2.
+    w /= w.sum()  # for now, the C++ code will require normalized w
+    f0 = dtype(df/2)  # f0=0 yields power[0] = nan. let's use f0=df/2, from LombScargle.autofrequency
 
-    power = np.zeros(M, dtype=y.dtype)
+    print(f'Running with {N=}, {M=}, dtype {dtype.__name__}')
 
-    nufft_ls_compute(t, y, w, f0, df, power)
+    if do_baseline or do_winding:
+        import nufft_ls.cpu
 
-    time = timeit.timeit('nufft_ls_compute(t, y, w, f0, df, power)',
-                number=(nloop:=3), globals=globals(),
-            )
-    print(f'baseline took {time/nloop:.4g} sec')
+    all_res = {}
 
-if do_astropy:=True:
-    # N.B. we are using a patched astropy that will do the computation in float32 if requested
-    apower = fast_impl.lombscargle_fast(t, y, dy=dy, f0=f0, df=df, Nf=M, use_fft=False, center_data=False, fit_mean=False)
-    atime = timeit.timeit('fast_impl.lombscargle_fast(t, y, dy=dy, f0=f0, df=df, Nf=M, use_fft=False, center_data=False, fit_mean=False)',
-                number=(nloop:=1), globals=globals(),
-            )
-    print(f'astropy took {atime/nloop:.4g} sec')
+    if do_baseline:
+        baseline_compute = {np.float32: nufft_ls.cpu.baseline_compute_float,
+                            np.float64: nufft_ls.cpu.baseline_compute,
+                        }[dtype]
 
-if dtype == np.float32:
-    isclose = lambda *args: np.isclose(*args, rtol=1e-4, atol=1e-7)
-else:
-    isclose = lambda *args: np.isclose(*args)
+        # static void compute(size_t N, const Scalar* t, const Scalar* y, const Scalar* w, size_t M,
+        #                       const Scalar f0, const Scalar df, Scalar* power);
 
-if do_nufft and do_astropy:
+        power = np.zeros(M, dtype=y.dtype)
+
+        baseline_compute(t, y, w, f0, df, power)
+        all_res['baseline'] = power.copy()
+
+        time = timeit.timeit('baseline_compute(t, y, w, f0, df, power)',
+                    number=(nloop:=10), globals=globals() | locals(),
+                )
+        print(f'baseline took {time/nloop:.4g} sec')
+
+    if do_winding:
+        winding_compute = {np.float32: nufft_ls.cpu.baseline_compute_winding_float,
+                                np.float64: nufft_ls.cpu.baseline_compute_winding,
+                            }[dtype]
+
+        power = np.zeros(M, dtype=y.dtype)
+
+        winding_compute(t, y, w, f0, df, power)
+        all_res['winding'] = power.copy()
+
+        time = timeit.timeit('winding_compute(t, y, w, f0, df, power)',
+                    number=(nloop:=10), globals=globals() | locals(),
+                )
+        print(f'winding baseline took {time/nloop:.4g} sec')
+
+    if do_astropy:
+        # N.B. we are using a patched astropy that will do the computation in float32 if requested
+        all_res['astropy'] = fast_impl.lombscargle_fast(t, y, dy=dy, f0=f0, df=df, Nf=M, use_fft=False, center_data=False, fit_mean=False)
+        atime = timeit.timeit('fast_impl.lombscargle_fast(t, y, dy=dy, f0=f0, df=df, Nf=M, use_fft=False, center_data=False, fit_mean=False)',
+                    number=(nloop:=1), globals=globals() | locals(),
+                )
+        print(f'astropy took {atime/nloop:.4g} sec')
+
+    # If we have more than 2 answers, compare!
+    compare(all_res, dtype)
+    
+    
+def compare(all_res, dtype):
+    if dtype == np.float32:
+        isclose = lambda *args: np.isclose(*args, rtol=1e-4, atol=1e-7)
+    else:
+        isclose = lambda *args: np.isclose(*args)
+
     # currently these don't match exactly in float32, even with the relaxed tolerance
-    print(f'frac isclose {isclose(power, apower).mean()*100:.4g}%')
-    print(f'max frac err {(np.abs(power-apower)/apower).max():.4g}')
-    #breakpoint()
+    for k,j in zip(all_res, list(all_res.keys())[1:]):
+        p1, p2 = all_res[k], all_res[j]
+        print(f'{k} vs {j}')
+        print(f'\tfrac isclose {isclose(p1, p2).mean()*100:.4g}%')
+        print(f'\tmax frac err {(np.abs(p1-p2)/p2).max():.4g}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-N', type=int, default=DEFAULT_N, help='N data')
+    parser.add_argument('-M', type=int, default=DEFAULT_M, help='M modes')
+    parser.add_argument('-dtype', default=DEFAULT_DTYPE, help='dtype', choices=('f4','f8'))
+
+    args = vars(parser.parse_args())
+    main(**args)

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -59,7 +59,7 @@ def main(N, M, dtype, df=DEFAULT_DF,
         all_res['baseline'] = power.copy()
 
         time = timeit.timeit('baseline_compute(t, y, w, f0, df, power)',
-                    number=(nloop:=20), globals=globals() | locals(),
+                    number=(nloop:=5), globals=globals() | locals(),
                 )
         print(f'baseline took {time/nloop:.4g} sec')
 

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -14,7 +14,7 @@ import threadpoolctl
 DEFAULT_N = 3554
 DEFAULT_M = 10**5
 DEFAULT_DTYPE = 'f8'
-DEFAULT_DF = np.dtype(DEFAULT_DTYPE).type(0.1)
+DEFAULT_DF = np.dtype(DEFAULT_DTYPE).type(1e-4)
 
 def main(N, M, dtype, df=DEFAULT_DF,
             do_baseline=True, do_astropy=True, do_winding=True):
@@ -59,7 +59,7 @@ def main(N, M, dtype, df=DEFAULT_DF,
         all_res['baseline'] = power.copy()
 
         time = timeit.timeit('baseline_compute(t, y, w, f0, df, power)',
-                    number=(nloop:=10), globals=globals() | locals(),
+                    number=(nloop:=20), globals=globals() | locals(),
                 )
         print(f'baseline took {time/nloop:.4g} sec')
 
@@ -74,7 +74,7 @@ def main(N, M, dtype, df=DEFAULT_DF,
         all_res['winding'] = power.copy()
 
         time = timeit.timeit('winding_compute(t, y, w, f0, df, power)',
-                    number=(nloop:=10), globals=globals() | locals(),
+                    number=(nloop:=20), globals=globals() | locals(),
                 )
         print(f'winding baseline took {time/nloop:.4g} sec')
 

--- a/include/periodogram/periodogram.hpp
+++ b/include/periodogram/periodogram.hpp
@@ -61,6 +61,76 @@ struct baseline {
   }
 
   template <typename Scalar>
+  static void compute_winding(size_t N, const Scalar* t, const Scalar* y, const Scalar* w, size_t M,
+                              const Scalar f0, const Scalar df, Scalar* power) {
+
+    const Scalar sqrt_half = std::sqrt(Scalar(0.5));
+    const Scalar domega = 2 * M_PI * df;
+    const Scalar omega0 = 2 * M_PI * f0;
+
+    // astropy's "standard" normalization
+    const Scalar norm = normalization(N, y, w);
+
+    Scalar sin = std::sin(omega0);
+    Scalar cos = std::cos(omega0);
+    const Scalar sindelta = std::sin(domega);
+    const Scalar cosdelta = std::cos(domega);
+
+    Scalar *sin_omegat = new Scalar[N];
+    Scalar *cos_omegat = new Scalar[N];
+    Scalar *sin_domegat = new Scalar[N];
+    Scalar *cos_domegat = new Scalar[N];
+    for(size_t n = 0; n < N; n++){
+        Scalar omega0t = omega0 * t[n];
+        Scalar domegat = domega * t[n];
+        sin_omegat[n] = std::sin(omega0t);
+        cos_omegat[n] = std::cos(omega0t);
+        sin_domegat[n] = std::sin(domegat);
+        cos_domegat[n] = std::cos(domegat);
+    }
+
+    for (size_t m = 0; m < M; ++m) {
+      Scalar Sh = Scalar(0), Ch = Scalar(0);
+      Scalar S2 = Scalar(0), C2 = Scalar(0);
+      #pragma omp simd simdlen(64/sizeof(Scalar))
+      for (size_t n = 0; n < N; ++n) {
+        Scalar wn = w[n];
+        Scalar hn = wn * y[n];
+        Scalar sin = sin_omegat[n];
+        Scalar cos = cos_omegat[n];
+
+        Sh += hn * sin;
+        Ch += hn * cos;
+
+        // sin(2*x) = 2 * sin(x) * cos(x)
+        // cos(2*x) = cos(x)*cos(x) - sin(x)*sin(x)
+        S2 += 2 * wn * sin * cos;
+        C2 += wn * (cos * cos - sin * sin);
+
+        // update sin/cos for omega + domega
+        sin_omegat[n] = sin_omegat[n] * cos_domegat[n] + cos_omegat[n] * sin_domegat[n];
+        cos_omegat[n] = cos_omegat[n] * cos_domegat[n] - sin * sin_domegat[n];
+      }
+
+      Scalar tan_2omega_tau = S2 / C2;
+
+      Scalar C2w = Scalar(1) / std::sqrt(1 + tan_2omega_tau * tan_2omega_tau);
+      Scalar S2w = tan_2omega_tau * C2w;
+      Scalar Cw = sqrt_half * std::sqrt(1 + C2w);
+      Scalar Sw = sqrt_half * sgn(S2w) * std::sqrt(1 - C2w);
+
+      Scalar YC = Ch * Cw + Sh * Sw;
+      Scalar YS = Sh * Cw - Ch * Sw;
+      Scalar CC = 0.5 * (1 + C2 * C2w + S2 * S2w);
+      Scalar SS = 0.5 * (1 - C2 * C2w - S2 * S2w);
+
+      power[m] = norm * (YC * YC / CC + YS * YS / SS);
+    }
+
+    delete[] sin_omegat, cos_omegat, sin_domegat, cos_domegat;
+  }
+
+  template <typename Scalar>
   static Scalar normalization(size_t N, const Scalar* y, const Scalar* w){
     Scalar invnorm = Scalar(0);
     for(size_t n = 0; n < N; ++n){

--- a/include/periodogram/periodogram.hpp
+++ b/include/periodogram/periodogram.hpp
@@ -71,11 +71,6 @@ struct baseline {
     // astropy's "standard" normalization
     const Scalar norm = normalization(N, y, w);
 
-    Scalar sin = std::sin(omega0);
-    Scalar cos = std::cos(omega0);
-    const Scalar sindelta = std::sin(domega);
-    const Scalar cosdelta = std::cos(domega);
-
     Scalar *sin_omegat = new Scalar[N];
     Scalar *cos_omegat = new Scalar[N];
     Scalar *sin_domegat = new Scalar[N];
@@ -127,7 +122,10 @@ struct baseline {
       power[m] = norm * (YC * YC / CC + YS * YS / SS);
     }
 
-    delete[] sin_omegat, cos_omegat, sin_domegat, cos_domegat;
+    delete[] sin_omegat;
+    delete[] cos_omegat;
+    delete[] sin_domegat;
+    delete[] cos_domegat;
   }
 
   template <typename Scalar>

--- a/src/nufft_ls/cpu.cpp
+++ b/src/nufft_ls/cpu.cpp
@@ -6,10 +6,12 @@
 
 namespace py = pybind11;
 
+enum Kind { SINCOS, WINDING };  // baseline implementations
+
 namespace periodogram_pybind {
     struct baseline {
         // TODO: do we need to disable forcecast?
-        template <typename Scalar>
+        template <typename Scalar, Kind K>
         static void compute(const py::array_t<Scalar, py::array::c_style> t,
                             const py::array_t<Scalar, py::array::c_style> y,
                             const py::array_t<Scalar, py::array::c_style> w,
@@ -24,7 +26,13 @@ namespace periodogram_pybind {
             size_t N = t.size();
             size_t M = power.size();
 
-            periodogram::baseline::compute<Scalar>(N, tptr, yptr, wptr, M, f0, df, pptr);
+            if constexpr (K == SINCOS) {
+                periodogram::baseline::compute<Scalar>(N, tptr, yptr, wptr, M, f0, df, pptr);
+            } else if constexpr (K == WINDING) {
+                periodogram::baseline::compute_winding<Scalar>(N, tptr, yptr, wptr, M, f0, df, pptr);
+            } else {
+                static_assert("Unknown baseline kind?");
+            }
         }
     };
 }
@@ -34,6 +42,9 @@ PYBIND11_MODULE(cpu, m) {
     //m.def("trig_sum_naive_compute", &periodogram::trig_sum_naive::compute<double>, "trig_sum_naive::compute<double>");
     //m.def("trig_sum_naive_compute_float", &periodogram::trig_sum_naive::compute<float>, "trig_sum_naive::compute<float>");
 
-    m.def("baseline_compute", &periodogram_pybind::baseline::compute<double>, "periodogram::baseline::compute<double>");
-    m.def("baseline_compute_float", &periodogram_pybind::baseline::compute<float>, "periodogram::baseline::compute<float>");
+    m.def("baseline_compute", &periodogram_pybind::baseline::compute<double, SINCOS>, "periodogram::baseline::compute<double>");
+    m.def("baseline_compute_float", &periodogram_pybind::baseline::compute<float, SINCOS>, "periodogram::baseline::compute<float>");
+
+    m.def("baseline_compute_winding", &periodogram_pybind::baseline::compute<double, WINDING>, "periodogram::baseline::compute_winding<double>");
+    m.def("baseline_compute_winding_float", &periodogram_pybind::baseline::compute<float, WINDING>, "periodogram::baseline::compute_winding<float>");
 }


### PR DESCRIPTION
Following up on #4, here's an initial implementation of the phase-winding idea on the CPU! The relevant function is `compute_winding()` in `periodogram.hpp`.

I'm not sure I've nailed the best implementation; I ended up needing 2 pairs per NU point, instead of the 1 pair @ahbarnett suggested.

The timings are better though:
#### `N=3554`, `M=10**5`, Skylake, ICC, 1 core
| | Astropy | Baseline | Winding |
| --- | --- | --- | --- |
| `float64` | 8.9 s | 890 ms | 310 ms |
| `float32` | 4.8 s | 420 ms | 160 ms |

`./bench/bench.py` will benchmark the baseline, winding baseline, and astropy versions (`--help` shows options), and checks that they get the same answer.

I thought about transposing the M and N loops to get to 1 pair per NU point, but it seems like that would require several M-length accmulator arrays, so I wasn't sure if that was better. I still might be missing something obvious though...